### PR TITLE
chores: hard disable disassembler, SFC CPU

### DIFF
--- a/higan/component/processor/wdc65816/instruction.cpp
+++ b/higan/component/processor/wdc65816/instruction.cpp
@@ -17,48 +17,60 @@ L PC.h = read(r.vector + 1);
 //controlled via the M/X flags, this changes the execution details of various instructions.
 //rather than implement four instruction tables for all possible combinations of these bits,
 //instead use macro abuse to generate all four tables based off of a single template table.
+#define opA(id, name, ...) case id: return instruction##name(__VA_ARGS__);
+#define opM(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
+#define m(name) &WDC65816::algorithm##name##8
+auto WDC65816::instructionMFXF() -> void {
+  #define opX(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
+  #define x(name) &WDC65816::algorithm##name##8
+  #include "instruction.hpp"
+  #undef opX
+  #undef x
+}
+auto WDC65816::instructionMFNoXF() -> void {
+  #define opX(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
+  #define x(name) &WDC65816::algorithm##name##16
+  #include "instruction.hpp"
+  #undef opX
+  #undef x
+}
+#undef opM
+#undef m
+#define opM(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
+#define m(name) &WDC65816::algorithm##name##16
+auto WDC65816::instructionNoMFXF() -> void {
+  #define opX(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
+  #define x(name) &WDC65816::algorithm##name##8
+  #include "instruction.hpp"
+  #undef opX
+  #undef x
+}
+auto WDC65816::instructionNoMFNoXF() -> void {
+  #define opX(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
+  #define x(name) &WDC65816::algorithm##name##16
+  #include "instruction.hpp"
+  #undef opX
+  #undef x
+}
+#undef opM
+#undef m
+#undef opA
+
 auto WDC65816::instruction() -> void {
   //a = instructions unaffected by M/X flags
   //m = instructions affected by M flag (1 = 8-bit; 0 = 16-bit)
   //x = instructions affected by X flag (1 = 8-bit; 0 = 16-bit)
-
-  #define opA(id, name, ...) case id: return instruction##name(__VA_ARGS__);
   if(MF) {
-    #define opM(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
-    #define m(name) &WDC65816::algorithm##name##8
     if(XF) {
-      #define opX(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
-      #define x(name) &WDC65816::algorithm##name##8
-      #include "instruction.hpp"
-      #undef opX
-      #undef x
+      instructionMFXF();
     } else {
-      #define opX(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
-      #define x(name) &WDC65816::algorithm##name##16
-      #include "instruction.hpp"
-      #undef opX
-      #undef x
+      instructionMFNoXF();
     }
-    #undef opM
-    #undef m
   } else {
-    #define opM(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
-    #define m(name) &WDC65816::algorithm##name##16
     if(XF) {
-      #define opX(id, name, ...) case id: return instruction##name##8(__VA_ARGS__);
-      #define x(name) &WDC65816::algorithm##name##8
-      #include "instruction.hpp"
-      #undef opX
-      #undef x
+      instructionNoMFXF();
     } else {
-      #define opX(id, name, ...) case id: return instruction##name##16(__VA_ARGS__);
-      #define x(name) &WDC65816::algorithm##name##16
-      #include "instruction.hpp"
-      #undef opX
-      #undef x
+      instructionNoMFNoXF();
     }
-    #undef opM
-    #undef m
   }
-  #undef opA
 }

--- a/higan/component/processor/wdc65816/wdc65816.hpp
+++ b/higan/component/processor/wdc65816/wdc65816.hpp
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#if defined(EMSCRIPTEN)
+#define INLINE_INSTRUCTIONS noinline
+#else
+#define INLINE_INSTRUCTIONS alwaysinline
+#endif
+
 namespace higan {
 
 struct WDC65816 {
@@ -228,6 +234,10 @@ struct WDC65816 {
   auto instructionPushEffectiveRelativeAddress() -> void;
 
   //instruction.cpp
+  INLINE_INSTRUCTIONS auto instructionMFXF() -> void;
+  INLINE_INSTRUCTIONS auto instructionMFNoXF() -> void;
+  INLINE_INSTRUCTIONS auto instructionNoMFXF() -> void;
+  INLINE_INSTRUCTIONS auto instructionNoMFNoXF() -> void;
   auto instruction() -> void;
 
   //serialization.cpp

--- a/higan/cv/cpu/cpu.cpp
+++ b/higan/cv/cpu/cpu.cpp
@@ -35,9 +35,12 @@ auto CPU::main() -> void {
     irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/fc/cpu/cpu.cpp
+++ b/higan/fc/cpu/cpu.cpp
@@ -31,9 +31,12 @@ auto CPU::main() -> void {
     return interrupt();
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/gb/cpu/cpu.cpp
+++ b/higan/gb/cpu/cpu.cpp
@@ -91,9 +91,12 @@ auto CPU::main() -> void {
     }
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(PC)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 
   if(Model::SuperGameBoy()) {

--- a/higan/gba/cpu/cpu.cpp
+++ b/higan/gba/cpu/cpu.cpp
@@ -43,9 +43,12 @@ auto CPU::main() -> void {
     context.halted = false;
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(pipeline.execute.address)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/md/apu/apu.cpp
+++ b/higan/md/apu/apu.cpp
@@ -39,9 +39,12 @@ auto APU::main() -> void {
     irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/md/cpu/cpu.cpp
+++ b/higan/md/cpu/cpu.cpp
@@ -51,9 +51,12 @@ auto CPU::main() -> void {
     }
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc - 4)) {
     eventInstruction->notify(disassembleInstruction(r.pc - 4), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/md/mcd/mcd.cpp
+++ b/higan/md/mcd/mcd.cpp
@@ -142,9 +142,12 @@ auto MCD::main() -> void {
     }
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc - 4)) {
     eventInstruction->notify(disassembleInstruction(r.pc - 4), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/ms/cpu/cpu.cpp
+++ b/higan/ms/cpu/cpu.cpp
@@ -35,9 +35,12 @@ auto CPU::main() -> void {
     irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/msx/cpu/cpu.cpp
+++ b/higan/msx/cpu/cpu.cpp
@@ -28,9 +28,12 @@ auto CPU::main() -> void {
     irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/ngp/apu/apu.cpp
+++ b/higan/ngp/apu/apu.cpp
@@ -50,9 +50,12 @@ auto APU::main() -> void {
     Z80::irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/ngp/cpu/cpu.cpp
+++ b/higan/ngp/cpu/cpu.cpp
@@ -77,9 +77,12 @@ auto CPU::main() -> void {
     return step(16);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc.l.l0)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/pce/cpu/cpu.cpp
+++ b/higan/pce/cpu/cpu.cpp
@@ -43,6 +43,7 @@ auto CPU::main() -> void {
     return interrupt(irq2.vector);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled()) {
     auto bank = r.mpr[r.pc >> 13];
     auto address = (uint13)r.pc;
@@ -52,6 +53,7 @@ auto CPU::main() -> void {
       });
     }
   }
+  #endif
 
   instruction();
 }

--- a/higan/sfc/coprocessor/armdsp/armdsp.cpp
+++ b/higan/sfc/coprocessor/armdsp/armdsp.cpp
@@ -35,9 +35,13 @@ auto ArmDSP::boot() -> void {
 
 auto ArmDSP::main() -> void {
   processor.cpsr.t = 0;  //force ARM mode
+
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(pipeline.execute.address)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/sfc/coprocessor/necdsp/necdsp.cpp
+++ b/higan/sfc/coprocessor/necdsp/necdsp.cpp
@@ -19,9 +19,12 @@ auto NECDSP::unload() -> void {
 }
 
 auto NECDSP::main() -> void {
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(regs.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   exec();
 
   Thread::step(1);

--- a/higan/sfc/coprocessor/sa1/sa1.cpp
+++ b/higan/sfc/coprocessor/sa1/sa1.cpp
@@ -47,9 +47,12 @@ auto SA1::main() -> void {
     return;
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc.d)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/sfc/coprocessor/superfx/superfx.cpp
+++ b/higan/sfc/coprocessor/superfx/superfx.cpp
@@ -30,9 +30,13 @@ auto SuperFX::main() -> void {
   if(regs.sfr.g == 0) return step(6);
 
   auto opcode = peekpipe();
+  
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(regs.r[15])) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+
   instruction(opcode);
 
   if(regs.r[14].modified) {

--- a/higan/sfc/cpu/cpu.cpp
+++ b/higan/sfc/cpu/cpu.cpp
@@ -35,11 +35,14 @@ auto CPU::main() -> void {
   if(r.stp) return instructionStop();
 
   if(!status.interruptPending) {
+    #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
     if(eventInstruction->enabled() && eventInstruction->address(r.pc.d)) {
       eventInstruction->notify(disassembleInstruction(), disassembleContext(), {
         "V:", pad(vcounter(), 3L), " ", "H:", pad(hcounter(), 4L), " I:", (uint)field()
       });
     }
+    #endif
+    
     return instruction();
   }
 

--- a/higan/sfc/smp/smp.cpp
+++ b/higan/sfc/smp/smp.cpp
@@ -33,9 +33,12 @@ auto SMP::main() -> void {
   if(r.wait) return instructionWait();
   if(r.stop) return instructionStop();
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc.w)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/sg/cpu/cpu.cpp
+++ b/higan/sg/cpu/cpu.cpp
@@ -35,9 +35,12 @@ auto CPU::main() -> void {
     irq(1, 0x0038, 0xff);
   }
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled() && eventInstruction->address(r.pc)) {
     eventInstruction->notify(disassembleInstruction(), disassembleContext());
   }
+  #endif
+  
   instruction();
 }
 

--- a/higan/target-web/GNUmakefile
+++ b/higan/target-web/GNUmakefile
@@ -5,6 +5,7 @@ debug_host := 127.0.0.1
 wasm := true
 debug := false
 synchro := true
+eventinstruction_notify := false
 
 ifeq ($(wasm), true)
   flags += -s WASM=1 
@@ -18,6 +19,10 @@ endif
 
 ifeq ($(synchro),true)
   flags += -DSCHEDULER_SYNCHRO
+endif
+
+ifeq ($(eventinstruction_notify), false)
+  flags += -DNO_EVENTINSTRUCTION_NOTIFY
 endif
 
 # -Werror 

--- a/higan/ws/cpu/cpu.cpp
+++ b/higan/ws/cpu/cpu.cpp
@@ -24,6 +24,7 @@ auto CPU::unload() -> void {
 auto CPU::main() -> void {
   poll();
 
+  #if !defined(NO_EVENTINSTRUCTION_NOTIFY)
   if(eventInstruction->enabled()
   && eventInstruction->address(uint20(V30MZ::r.cs * 16 + V30MZ::r.ip))
   ) {
@@ -31,6 +32,8 @@ auto CPU::main() -> void {
       eventInstruction->notify(instruction, disassembleContext());
     }
   }
+  #endif
+  
   exec();
 }
 


### PR DESCRIPTION
This PR does two things:

1. Add a flag to hard turn-off event instruction notifications,
   which will force every processor's disassembler functions into DCE
2. Break down the WDC65816 instruction function and make inlining optional,
   which seems to reduce/remove instances of crashes on iOS devices by
   reducing the compiled function's sizes

Before:

```
    FILE SIZE        VM SIZE
 --------------  --------------
  77.2%  3.61Mi   NAN%       0    [4903 Others]
   3.5%   168Ki   NAN%       0    [section Data]
   3.0%   144Ki   NAN%       0    higan::WDC65816::instruction()
   2.2%   103Ki   NAN%       0    higan::WDC65816::disassembleInstruction(nall::Natural<24u>, bool, bool, bool)
   1.6%  77.5Ki   NAN%       0    higan::MOS6502::disassembleInstruction(nall::maybe<nall::Natural<16u> >)
   1.4%  68.0Ki   NAN%       0    higan::SPC700::disassembleInstruction(nall::Natural<16u>, nall::Natural<1u>)::$_0::operator()() const
   1.3%  63.4Ki   NAN%       0    icarus::SuperFamicom::heuristics(nall::vector<unsigned char>&, nall::string)
   1.3%  63.1Ki   NAN%       0    higan::SPC700::instruction()
   1.0%  49.2Ki   NAN%       0    __wasm_call_ctors
   0.9%  45.3Ki   NAN%       0    higan::HG51B::HG51B()
   0.9%  41.4Ki   NAN%       0    higan::SuperFamicom::NTTDataKeypad::NTTDataKeypad(nall::shared_pointer<higan::Core::Port>, nall::shared_pointer<higan::Core::Peripheral>)
   0.8%  38.2Ki   NAN%       0    higan::MOS6502::instruction()
   0.7%  33.6Ki   NAN%       0    higan::ARM7TDMI::armInitialize()
   0.6%  26.4Ki   NAN%       0    higan::ARM7TDMI::thumbInitialize()
   0.5%  25.4Ki   NAN%       0    icarus::Famicom::heuristicsINES(nall::vector<unsigned char>&, nall::string)
   0.5%  25.2Ki   NAN%       0    higan::SuperFamicom::PPU::load(nall::shared_pointer<higan::Core::Object>, nall::shared_pointer<higan::Core::Object>)
   0.5%  25.1Ki   NAN%       0    higan::Famicom::PPU::load(nall::shared_pointer<higan::Core::Object>, nall::shared_pointer<higan::Core::Object>)
   0.5%  24.9Ki   NAN%       0    SuperFamicom::open(nall::shared_pointer<higan::Core::Object>, nall::string, nall::vfs::file::mode, bool)
   0.5%  22.6Ki   NAN%       0    higan::Famicom::FDS::connect(nall::shared_pointer<higan::Core::Peripheral>)
   0.5%  21.9Ki   NAN%       0    higan::ARM7TDMI::thumbInstructionALU(nall::Natural<3u>, nall::Natural<3u>, nall::Natural<4u>)
   0.4%  21.1Ki   NAN%       0    icarus::MegaDrive::heuristics(nall::vector<unsigned char>&, nall::string)
 100.0%  4.67Mi 100.0%       0    TOTAL
```

After:

```
    FILE SIZE        VM SIZE
 --------------  --------------
  81.3%  3.55Mi   NAN%       0    [4860 Others]
   3.7%   165Ki   NAN%       0    [section Data]
   1.4%  63.4Ki   NAN%       0    icarus::SuperFamicom::heuristics(nall::vector<unsigned char>&, nall::string)
   1.4%  63.1Ki   NAN%       0    higan::SPC700::instruction()
   1.1%  49.2Ki   NAN%       0    __wasm_call_ctors
   1.0%  45.3Ki   NAN%       0    higan::HG51B::HG51B()
   0.9%  41.4Ki   NAN%       0    higan::SuperFamicom::NTTDataKeypad::NTTDataKeypad(nall::shared_pointer<higan::Core::Port>, nall::shared_pointer<higan::Core::Peripheral>)
   0.9%  38.2Ki   NAN%       0    higan::MOS6502::instruction()
   0.8%  37.4Ki   NAN%       0    higan::WDC65816::instructionMFXF()
   0.8%  36.7Ki   NAN%       0    higan::WDC65816::instructionMFNoXF()
   0.8%  35.6Ki   NAN%       0    higan::WDC65816::instructionNoMFXF()
   0.8%  34.8Ki   NAN%       0    higan::WDC65816::instructionNoMFNoXF()
   0.8%  33.6Ki   NAN%       0    higan::ARM7TDMI::armInitialize()
   0.6%  26.4Ki   NAN%       0    higan::ARM7TDMI::thumbInitialize()
   0.6%  25.4Ki   NAN%       0    icarus::Famicom::heuristicsINES(nall::vector<unsigned char>&, nall::string)
   0.6%  25.2Ki   NAN%       0    higan::SuperFamicom::PPU::load(nall::shared_pointer<higan::Core::Object>, nall::shared_pointer<higan::Core::Object>)
   0.6%  25.1Ki   NAN%       0    higan::Famicom::PPU::load(nall::shared_pointer<higan::Core::Object>, nall::shared_pointer<higan::Core::Object>)
   0.6%  24.9Ki   NAN%       0    SuperFamicom::open(nall::shared_pointer<higan::Core::Object>, nall::string, nall::vfs::file::mode, bool)
   0.5%  22.6Ki   NAN%       0    higan::Famicom::FDS::connect(nall::shared_pointer<higan::Core::Peripheral>)
   0.5%  21.9Ki   NAN%       0    higan::ARM7TDMI::thumbInstructionALU(nall::Natural<3u>, nall::Natural<3u>, nall::Natural<4u>)
   0.5%  21.1Ki   NAN%       0    icarus::MegaDrive::heuristics(nall::vector<unsigned char>&, nall::string)
 100.0%  4.37Mi 100.0%       0    TOTAL
```

After (debug off):

```
    FILE SIZE        VM SIZE
 --------------  --------------
  80.1%  3.28Mi   NAN%       0    [4556 Others]
   4.0%   165Ki   NAN%       0    [section Data]
   1.5%  63.3Ki   NAN%       0    func[2181]
   1.5%  63.1Ki   NAN%       0    func[2663]
   1.2%  49.2Ki   NAN%       0    func[4566]
   1.1%  45.3Ki   NAN%       0    func[2931]
   1.0%  41.3Ki   NAN%       0    func[4349]
   0.9%  38.1Ki   NAN%       0    func[2705]
   0.9%  37.4Ki   NAN%       0    func[2535]
   0.9%  36.6Ki   NAN%       0    func[2534]
   0.8%  35.5Ki   NAN%       0    func[2533]
   0.8%  34.8Ki   NAN%       0    func[2531]
   0.8%  33.6Ki   NAN%       0    func[3325]
   0.6%  26.3Ki   NAN%       0    func[3324]
   0.6%  25.3Ki   NAN%       0    func[2193]
   0.6%  25.1Ki   NAN%       0    func[3908]
   0.6%  25.0Ki   NAN%       0    func[4556]
   0.6%  24.8Ki   NAN%       0    func[2475]
   0.5%  22.5Ki   NAN%       0    func[4487]
   0.5%  21.8Ki   NAN%       0    func[3307]
   0.5%  21.0Ki   NAN%       0    func[2189]
 100.0%  4.09Mi 100.0%       0    TOTAL
```