### PR TITLE
fix: terminate

### DIFF
--- a/higan/target-web/api.js
+++ b/higan/target-web/api.js
@@ -94,7 +94,9 @@ byuu.initialize = async function (container, height, width) {
 }
 
 byuu.terminate = () => {
+  byuu.stop()
   byuu.unload()
+  getModule().terminate()
   canvas.parentElement.removeChild(canvas)
 }
 

--- a/higan/target-web/audio/audio.cpp
+++ b/higan/target-web/audio/audio.cpp
@@ -42,6 +42,13 @@ void WebAudio::initialize() {
     }
 }
 
+void WebAudio::terminate() {
+    free(buffer);
+    bufferLength = 0;
+    alcDestroyContext(context);
+    alcCloseDevice(device);
+}
+
 bool WebAudio::resume() {
     return EM_ASM_INT({
         if(!AL) {

--- a/higan/target-web/audio/audio.hpp
+++ b/higan/target-web/audio/audio.hpp
@@ -21,6 +21,8 @@ struct WebAudio {
 	uint bufferSize = 0;
 
 	void initialize();
+	void terminate();
+
 	bool resume();
 	void output(double samples[2]);
 };

--- a/higan/target-web/package.json
+++ b/higan/target-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byuu",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "homepage": "https://github.com/wizcorp/byuu-web#readme",
   "repository": "github:wizcorp/byuu-web",
   "bugs": {

--- a/higan/target-web/platform/platform.cpp
+++ b/higan/target-web/platform/platform.cpp
@@ -17,6 +17,11 @@ auto WebPlatform::initialize(const char *windowTitle, uint width, uint height) -
     return true;
 };
 
+auto WebPlatform::terminate() -> void {
+    webaudio.terminate();
+    webvideo.terminate();
+}
+
 auto WebPlatform::getEmulatorForFilename(const char *path) -> string {
     auto ext = getFilenameExtension(path);
 

--- a/higan/target-web/platform/platform.hpp
+++ b/higan/target-web/platform/platform.hpp
@@ -47,6 +47,7 @@ struct WebPlatform : higan::Platform {
         WebPlatform();
 
         auto initialize(const char *windowTitle, uint width, uint height) -> bool;
+        auto terminate() -> void;
 
         auto getROMInfo(const char *path, uint8_t *rom, int size) -> emscripten::val;
         

--- a/higan/target-web/video/video.cpp
+++ b/higan/target-web/video/video.cpp
@@ -10,6 +10,13 @@ void WebVideo::initialize(const char* windowTitle, uint width, uint height) {
     }
 }
 
+void WebVideo::terminate() {
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+    SDL_RenderClear(renderer);
+    SDL_DestroyTexture(texture);
+    texture = nullptr;
+}
+
 void WebVideo::resize(uint width, uint height) {
     SDL_SetWindowSize(window, width, height);
 }
@@ -27,7 +34,6 @@ void WebVideo::render(const void *data, uint pitch, uint frameWidth, uint frameH
     }
     
     SDL_UpdateTexture(texture, nullptr, data, pitch);
-    SDL_RenderClear(renderer);
     SDL_RenderCopy(renderer, texture, nullptr, nullptr);
     SDL_RenderPresent(renderer);
 }

--- a/higan/target-web/video/video.hpp
+++ b/higan/target-web/video/video.hpp
@@ -9,6 +9,7 @@ struct WebVideo {
 	uint height = 224;
 
     void initialize(const char *windowTitle, uint width, uint height);
+	void terminate();
 	void resize(uint width, uint height);
     void render(const void *data, uint pitch, uint frameWidth, uint frameHeight);
 };

--- a/higan/target-web/web.cpp
+++ b/higan/target-web/web.cpp
@@ -51,6 +51,7 @@ void unload() {
 
 /*  bootstrap */
 bool initialize(std::string windowTitle, uint width, uint height) { return webplatform->initialize(windowTitle.c_str(), width, height); }
+void terminate() { return webplatform->terminate(); }
 
 std::string getEmulatorForFilename(std::string path) { return webplatform->getEmulatorForFilename(path.c_str()).data(); };
 emscripten::val getROMInfo(std::string path, std::string rom) { return webplatform->getROMInfo(path.c_str(), (uint8_t *) rom.c_str(), rom.size()); }
@@ -80,6 +81,7 @@ emscripten::val save() { return webplatform->save(); }
 
 EMSCRIPTEN_BINDINGS(my_module) {
     emscripten::function("initialize", &initialize);
+    emscripten::function("terminate", &terminate);
     emscripten::function("getEmulatorForFilename", &getEmulatorForFilename);
     emscripten::function("setEmulator", &setEmulator);
     emscripten::function("setEmulatorForFilename", &setEmulatorForFilename);


### PR DESCRIPTION
Terminate now clears audio & video; this solves an issue where
starting a new game after unload would still display the last
frame rendered and play the leftover audio buffer content.