### PR TITLE
Support Dualshock4 on iOS Safari

### DIFF
--- a/higan/target-web/shell.html
+++ b/higan/target-web/shell.html
@@ -2068,6 +2068,22 @@
             'Select', 'Start', null, null, 'Up', 'Down', 'Left', 'Right'
           ]
         },
+        // PS4 Controller (as detected on iOS Safari)
+        // L/R duplicated for convenience
+        'DUALSHOCK 4 Wireless Controller Extended Gamepad': {
+          'Famicom': [
+            'A', 'B', 'X', 'Y', 'L', 'R', 'L', 'R',
+            'Select', 'Start', null, null, 'Up', 'Down', 'Left', 'Right'
+          ],
+          'Super Famicom': [
+            'A', 'B', 'X', 'Y', 'L', 'R', 'L', 'R',
+            'Select', 'Start', null, null, 'Up', 'Down', 'Left', 'Right'
+          ],
+          'Mega Drive': [
+            'A', 'B', 'X', 'Y', 'C', 'Z', 'C', 'Z',
+            'Select', 'Start', null, null, 'Up', 'Down', 'Left', 'Right'
+          ]
+        },
         // Switch PRO Controller
         // L/R duplicated for convenience
         // Select/Start duplicated for convenience


### PR DESCRIPTION
on iOS Safari, the dualshock4 controller is detected with this id: 'DUALSHOCK 4 Wireless Controller Extended Gamepad'